### PR TITLE
Fix call to get_schema_view

### DIFF
--- a/dronesim/urls.py
+++ b/dronesim/urls.py
@@ -35,7 +35,7 @@ schema_view = get_schema_view(
         license=openapi.License(name="MIT License"),
     ),
     public=True,
-    permission_classes=(permissions.AllowAny,),
+    permission_classes=[permissions.AllowAny],
 )
 
 router = routers.DefaultRouter()

--- a/simulator/tasks.py
+++ b/simulator/tasks.py
@@ -81,7 +81,7 @@ def simulate_dynamics(dynamics, yaw=-1, timestamp=timezone.now()):
         new_speed = 0
     return DroneDynamics(drone=dynamics.drone, speed=new_speed, align_roll=0, align_pitch=0, align_yaw=new_yaw, longitude=new_long, latitude=new_lat, battery_status=new_battery, last_seen=timestamp, timestamp=timestamp, status=new_status)
 
-# Default time window is 24hrs with a delta of 60 secs = 1440 entries per drone. Per default, 10 drones are created
+# Default time window is 24hrs with a delta of 60 secs = 1440 entries per drone. Per default, 20 drones are created
 @app.task
 def init_static_drones(init_delta_min=1440, tick_delta_sec=60, n=20):
     dronetypes = [


### PR DESCRIPTION
The parameter `permission_classes` passed to the method `get_schema_view` is supposed to be of type list instead of tuple (see [documentation](https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html#drf_yasg.views.get_schema_view)).

I also changed the comment in `tasks.py` to reflect the new default value of `n`.