### PR TITLE
Order drone id specific dynamics by timestamp

### DIFF
--- a/simulator/views.py
+++ b/simulator/views.py
@@ -74,7 +74,7 @@ class DroneDynamicListAPIView(generics.ListAPIView):
         """
         drone_id = self.kwargs['drone_id']
         drone = get_object_or_404(Drone, pk=drone_id)
-        return drone.dynamics.all()
+        return drone.dynamics.all().order_by('timestamp')
 
 # Helper for context
 def create_context(request):


### PR DESCRIPTION
The general drone dynamics endpoint is ordered as well so it only makes sense to provide a ordered set here too.