### PR TITLE
Fix latitude and longitude mixup

### DIFF
--- a/simulator/tasks.py
+++ b/simulator/tasks.py
@@ -15,6 +15,7 @@ def create_initial_drone_dynamics(drone, place_id=-1, timestamp=timezone.now()):
     Creates an initial drone dynamics orm object. If the place_id is -1, a random place is chosen
     """
     places = (
+            # (name, latitude, longitude)
             ("Frankfurt Hauptbahnhof", 50.107185833, 8.663789667),
             ("Römerberg", 50.110924000, 8.682127000),
             ("Palmengarten", 50.120598000, 8.657251000),
@@ -29,7 +30,7 @@ def create_initial_drone_dynamics(drone, place_id=-1, timestamp=timezone.now()):
     place = random.choice(places)
     if place_id != -1:
         place = places[place_id]
-    return DroneDynamics(drone=drone, speed=drone.dronetype.max_speed, align_roll=0.0, align_pitch=0.0, align_yaw=0.0, longitude=place[1], latitude=place[2], battery_status=drone.dronetype.battery_capacity, last_seen=timestamp, timestamp=timestamp, status = "ON")
+    return DroneDynamics(drone=drone, speed=drone.dronetype.max_speed, align_roll=0.0, align_pitch=0.0, align_yaw=0.0, longitude=place[2], latitude=place[1], battery_status=drone.dronetype.battery_capacity, last_seen=timestamp, timestamp=timestamp, status = "ON")
 
 def calculate_new_coordinates(longitude, latitude, speed, heading, last_sighting_time, current_time):
     heading_rad = radians(heading)


### PR DESCRIPTION
As of right now, latitude and longitude values are mixed up. 

This is what the data looks like right now for `GET /api/51/dynamics/?limit=1`.
```json
{
    "count": 1441,
    "next": "http://dronesim.facets-labs.com/api/51/dynamics/?limit=1&offset=1",
    "previous": null,
    "results": [
        {
            "drone": "http://dronesim.facets-labs.com/api/drones/51/",
            "timestamp": "2023-11-30T15:43:27.820969+01:00",
            "speed": 36,
            "align_roll": "0.00",
            "align_pitch": "0.00",
            "align_yaw": "0.00",
            "longitude": "50.039364000",
            "latitude": "8.214841000",
            "battery_status": 750,
            "last_seen": "2023-11-30T15:43:27.820969+01:00",
            "status": "ON"
        }
    ]
}
```

Now if we look up the latitude and longitude values for Frankfurt, e.g. on [latlong.net](https://www.latlong.net/), we can tell that the values above are mixed up. This pull request resolves this issue. For it becoming effective however, it seems to be necessary to flush and reinitialize the database.
